### PR TITLE
Added strokeWidth for ring style charts

### DIFF
--- a/lib/src/chart_painter.dart
+++ b/lib/src/chart_painter.dart
@@ -19,6 +19,7 @@ class PieChartPainter extends CustomPainter {
   final ChartType chartType;
   final String centerText;
   final Function formatChartValues;
+  final double strokeWidth;
 
   double _prevAngle = 0;
 
@@ -35,13 +36,14 @@ class PieChartPainter extends CustomPainter {
     this.showChartValueLabel,
     this.chartType,
     this.centerText,
-    this.formatChartValues
+    this.formatChartValues,
+    this.strokeWidth,
   }) {
     for (int i = 0; i < values.length; i++) {
       final paint = Paint()..color = getColor(colorList, i);
       if (chartType == ChartType.ring) {
         paint.style = PaintingStyle.stroke;
-        paint.strokeWidth = 20;
+        paint.strokeWidth = strokeWidth;
       }
       _paintList.add(paint);
     }
@@ -70,8 +72,8 @@ class PieChartPainter extends CustomPainter {
           math.sin(
               _prevAngle + ((((_totalAngle) / _total) * _subParts[i]) / 2));
       if (_subParts.elementAt(i).toInt() != 0) {
-        final value = formatChartValues != null 
-            ? formatChartValues(_subParts.elementAt(i)) 
+        final value = formatChartValues != null
+            ? formatChartValues(_subParts.elementAt(i))
             : _subParts.elementAt(i).toStringAsFixed(this.decimalPlaces);
         final name = showValuesInPercentage
             ? (((_subParts.elementAt(i) / _total) * 100)

--- a/lib/src/pie_chart.dart
+++ b/lib/src/pie_chart.dart
@@ -29,6 +29,7 @@ class PieChart extends StatefulWidget {
     this.decimalPlaces = 0,
     this.formatChartValues,
     this.centerText,
+    this.strokeWidth = 20.0,
     Key key,
   }) : super(key: key);
 
@@ -57,6 +58,7 @@ class PieChart extends StatefulWidget {
   final double initialAngle;
   final Function formatChartValues;
   final String centerText;
+  final double strokeWidth;
 
   @override
   _PieChartState createState() => _PieChartState();
@@ -149,7 +151,8 @@ class _PieChartState extends State<PieChart>
               showChartValueLabel: widget.showChartValueLabel,
               chartType: widget.chartType,
               centerText: widget.centerText,
-              formatChartValues: widget.formatChartValues
+              formatChartValues: widget.formatChartValues,
+              strokeWidth: widget.strokeWidth,
             ),
             child: AspectRatio(aspectRatio: 1),
           ),


### PR DESCRIPTION
Just added the strokeWidth for Ring charts with a default width of 20.0, which is was it was set to previously.
Also used the flutter formatter which seems to have removed a couple of spaces.