### PR TITLE
Allow several columns for legend

### DIFF
--- a/lib/src/pie_chart.dart
+++ b/lib/src/pie_chart.dart
@@ -167,7 +167,9 @@ class _PieChartState extends State<PieChart>
         fit: FlexFit.loose,
         child: Padding(
           padding: legendSpacing,
-          child: Column(
+          child: Wrap(
+            direction: Axis.vertical,
+            runSpacing: 8,
             crossAxisAlignment: CrossAxisAlignment.start,
             mainAxisSize: MainAxisSize.min,
             children: legendTitles


### PR DESCRIPTION
Use a vertical Wrap instead of a Column so that items will occupy several columns instead of one if there is not enough vertical space.