### PR TITLE
fix: showChartValues parameter

### DIFF
--- a/lib/src/chart_painter.dart
+++ b/lib/src/chart_painter.dart
@@ -13,6 +13,7 @@ class PieChartPainter extends CustomPainter {
   final Color chartValueBackgroundColor;
   final double initialAngle;
   final bool showValuesInPercentage;
+  final bool showChartValues;
   final bool showChartValuesOutside;
   final int decimalPlaces;
   final bool showChartValueLabel;
@@ -25,6 +26,7 @@ class PieChartPainter extends CustomPainter {
 
   PieChartPainter(
     double angleFactor,
+    this.showChartValues,
     this.showChartValuesOutside,
     List<Color> colorList, {
     this.chartValueStyle,
@@ -75,13 +77,16 @@ class PieChartPainter extends CustomPainter {
         final value = formatChartValues != null
             ? formatChartValues(_subParts.elementAt(i))
             : _subParts.elementAt(i).toStringAsFixed(this.decimalPlaces);
-        final name = showValuesInPercentage
-            ? (((_subParts.elementAt(i) / _total) * 100)
-                    .toStringAsFixed(this.decimalPlaces) +
-                '%')
-            : value;
 
-        _drawName(canvas, name, x, y, side);
+        if (showChartValues) {
+          final name = showValuesInPercentage
+              ? (((_subParts.elementAt(i) / _total) * 100)
+              .toStringAsFixed(this.decimalPlaces) +
+              '%')
+              : value;
+
+          _drawName(canvas, name, x, y, side);
+        }
       }
       _prevAngle = _prevAngle + (((_totalAngle) / _total) * _subParts[i]);
     }

--- a/lib/src/pie_chart.dart
+++ b/lib/src/pie_chart.dart
@@ -140,6 +140,7 @@ class _PieChartState extends State<PieChart>
           child: CustomPaint(
             painter: PieChartPainter(
               _fraction,
+              widget.showChartValues,
               widget.showChartValuesOutside,
               widget.colorList,
               chartValueStyle: widget.chartValueStyle,


### PR DESCRIPTION
`showChartValues` had no effetct at all. This PR fixes it & implements the missing part for this parameter, so setting it to `true` or `false` will work properly.

An example with `showChartValues=false`
![qemu-system-x86_64_2020-08-29_23-46-10](https://user-images.githubusercontent.com/28513447/91646010-81421c00-ea53-11ea-9f3d-84d033dc410b.png)


Addresses apgapg/pie_chart#48